### PR TITLE
Jekyll does not exist errors during `yarn ig-gen` - Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@ FHIR Implementation Guide for CMS Data Element Library
 
 This is still a work in progress. More documentation to come.
 
-You will need yarn and java11 installed and on your PATH.
+You will need:
+* `yarn`
+* `ruby` (version 2.6.x or greater)
+* java11
+* `jekyll`
+
+installed and on your PATH.
 
 Install dependencies:
 


### PR DESCRIPTION
I was getting errors that `jekyll` did not exist when running `yarn ig-gen`. After installing the `jekyll` cli gem. Everything ran successfully.